### PR TITLE
Use promise to sequence alert after clipboard write

### DIFF
--- a/Prog-Langle/src/routes/+page.svelte
+++ b/Prog-Langle/src/routes/+page.svelte
@@ -176,9 +176,13 @@
 
 		text += '`'
 
-		navigator.clipboard.writeText(text);
-
-		alert("Results copied to clipboard")
+		navigator.clipboard.writeText(text)
+			.then(() => {
+				alert("Results copied to clipboard")
+			})
+			.catch(_ => {
+				alert("Could not copy results to clipboard")
+			})
     }
 </script>
 


### PR DESCRIPTION
This means that the alert is only shown after the results are actually copied, definitely did not lose a few seconds of head scratching on this 😛 